### PR TITLE
Demonstrating doctest failure case

### DIFF
--- a/example_doctest.py
+++ b/example_doctest.py
@@ -14,7 +14,7 @@ def group_indices(array):
     -------
     : iterable of slice objects
 
-    >>> indices = np.array([0, 1, 2, 4, 5, 6, 8, 9])
+    >>> indices = np.array([0, 1, 2, 4, 5, 6, 8, 10])
     >>> group_indices(indices)
     [slice(0, 3, None), slice(4, 7, None), slice(8, 10, None)]
 


### PR DESCRIPTION
```
$ python example_doctest.py
**********************************************************************
File "example_doctest.py", line 18, in __main__.group_indices
Failed example:
    group_indices(indices)
Expected:
    [slice(0, 3, None), slice(4, 7, None), slice(8, 10, None)]
Got:
    [slice(0, 3, None), slice(4, 7, None), slice(8, 9, None), slice(10, 11, None)]
**********************************************************************
1 items had failures:
   1 of   2 in __main__.group_indices
***Test Failed*** 1 failures.
```